### PR TITLE
Resolve tz from iana in a case-insensitive manner.

### DIFF
--- a/Src/TimeZoneDb.Tests/Integration/UseCaseTests.cs
+++ b/Src/TimeZoneDb.Tests/Integration/UseCaseTests.cs
@@ -11,9 +11,19 @@ namespace TimeZoneDb.Tests.Integration
     {
         #region Fields
 
-        private ITimeZoneDbUseCases _timeZoneDbUseCases = new TimeZoneDbUseCases();
+        private static ITimeZoneDbUseCases _timeZoneDbUseCases;
 
         #endregion
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            // this became static because instantiating this thing takes ages
+            if (_timeZoneDbUseCases == null)
+            {
+                _timeZoneDbUseCases = new TimeZoneDbUseCases();
+            }
+        }
 
         [TestMethod]
         public void GetAllTimeZones()
@@ -27,6 +37,13 @@ namespace TimeZoneDb.Tests.Integration
         public void GetTimeZoneWithIanaId()
         {
             var timeZone = _timeZoneDbUseCases.GetTimeZoneWithIanaId("America/Los_Angeles");
+            Assert.IsNotNull(timeZone);
+        }
+
+        [TestMethod]
+        public void GetTimeZoneWithIanaId_WrongCaseResolves()
+        {
+            var timeZone = _timeZoneDbUseCases.GetTimeZoneWithIanaId("america/los_angeles");
             Assert.IsNotNull(timeZone);
         }
     }

--- a/Src/TimeZoneDb/Repositories/InMemoryTimeZoneRepository.cs
+++ b/Src/TimeZoneDb/Repositories/InMemoryTimeZoneRepository.cs
@@ -11,7 +11,7 @@ namespace TimeZoneDb.Repositories
 
         public InMemoryTimeZoneRepository()
         {
-            _timeZoneDatabase = new ConcurrentDictionary<string, DbTimeZone>();
+            _timeZoneDatabase = new ConcurrentDictionary<string, DbTimeZone>(StringComparer.OrdinalIgnoreCase);
         }
 
         #endregion


### PR DESCRIPTION
I suggest here a way to implement case-insensitive resolution of IANA time zones. I added a unit test.

This is related to issue #7 .

Note: I made the test target static in the unit test because it took ~20 seconds to instantiate.